### PR TITLE
Corrected a typo in LookupHelper.js

### DIFF
--- a/src/main/default/aura/Lookup/LookupHelper.js
+++ b/src/main/default/aura/Lookup/LookupHelper.js
@@ -4,7 +4,7 @@
         component.set('v.searchTerm', searchTerm);
         
         // Get previous clean search term
-        const cleanSearchTerm = component.set('v.cleanSearchTerm');
+        const cleanSearchTerm = component.get('v.cleanSearchTerm');
 
         // Compare clean new search term with current one and abort if identical
         const newCleanSearchTerm = searchTerm.trim().replace(/\*/g, '').toLowerCase();


### PR DESCRIPTION
On line 7, there was a component.set instead of component.get, resulting in an always undefined value for cleanSearchTerm.